### PR TITLE
fix : camera - Vector2 to list

### DIFF
--- a/code/level.py
+++ b/code/level.py
@@ -6,8 +6,9 @@ from settings import *
 from support import *
 from player import *
 from random import choice
+from debug import *
 
-class Level():
+class Level:
     def __init__(self):
         self.player_size = (200, 200)
 
@@ -36,14 +37,45 @@ class CameraGroup(pygame.sprite.Group): # Not implemented yet
         super(CameraGroup, self).__init__()
         self.display_surface = pygame.display.get_surface()
 
+        # for camera
+        self.half_width = self.display_surface.get_width() // 2 # x 포지션에 사용할 화면 크기
+        self.half_height = self.display_surface.get_height() // 2 # 층 만들면 그때 사용할 예정
+
+        # 오프셋 세팅
+        self.offset = [0, 0]
+
+        # 오프셋 변경 기준 x점
+        self.left_x_point = 639 # 이 오프셋 포인트 기준으로 플레이어가 오른쪽으로 향하면 그 후로는 플레이어가 화면 중심에 있음
+        self.right_x_point = 2800 # 이 오프셋 포인트 기준으로 플레이어가 왼쪽으로 향하면 그 후로는 플레이어가 화면 중심에 있음
+        # 위의 포인트 사이에 있을 경우 플레이어는 항상 화면 가운데에 있지만
+        # left 포인트보다 왼쪽에 있을 경우에는 오프셋은 left_x_point가 기준이된다. 반대의 경우도 마찬가지다. # custom_draw의 해당 코드에 또 주석 달아놓았음
+
         #creating the floor s
         self.background_sky_surf = pygame.image.load('image/map/Start_Sky.png')
         self.background_sky_rect = self.background_sky_surf.get_rect(topleft=(0,0))
+
         self.background_floor_surf = pygame.image.load('image/map/Start_Map.png')
+        self.background_floor_surf = pygame.transform.scale(self.background_floor_surf, (3500, 897)) # 화면 변화 속도가 달라서 바닥만 대충 크게 리사이즈함. 이미지 리소스 바꾸면 값 바꿀 것
         self.background_floor_rect = self.background_floor_surf.get_rect(topleft=(0,0))
 
     def custom_draw(self, player):
-        self.display_surface.blit(self.background_sky_surf, (0,0))
-        self.display_surface.blit(self.background_floor_surf, (0,-150))
+        # offset setting
+        if player.rect.centerx <= self.left_x_point: # 시작 화면으로부터 left_x_point 범위에 플레이어가 있을 때는 카메라 이동 없음
+            self.offset[0] = self.left_x_point - self.half_width
+        elif player.rect.centerx >= self.right_x_point: # right_x_point 부터 끝 장면까지 범위에 플레이어가 있을 때는 카메라 이동 없음
+            self.offset[0] = self.right_x_point - self.half_width
+        else: # left_x_point ~ right_x_point 사이에 플레이어가 있을 때는 플레이어가 중심에 있을 수 있도록 카메라를 이동시킴
+            self.offset[0] = player.rect.centerx - self.half_width
+
+        # 멀리 있는 물체가 더 느리게 변화하고 바닥 물체가 더 빠르게 변화하므로 바닥이 멀리 있는 물체보다 이미지 사이즈가 커야함.
+        # 스케일을 맞춰볼까? :
+        floor_offset_pos = sub_Coordinate(self.background_floor_rect.topleft, self.offset)
+        sky_offset_pos = sub_Coordinate(self.background_sky_rect.topleft, self.offset)
+        sky_offset_pos[0] *= 0.3 # 멀리있는 하늘은 x포지션의 변화 속도를 가까이있는 바닥보다 느리게 만들기
+
+        self.display_surface.blit(self.background_sky_surf, sky_offset_pos)
+        self.display_surface.blit(self.background_floor_surf, add_Coordinate(floor_offset_pos, (0, -150)))
+
         for sprite in sorted(self.sprites(), key= lambda sprite: sprite.rect.centery):
-            self.display_surface.blit(sprite.image, sprite.rect.topleft)
+            offset_position = sub_Coordinate(sprite.rect.topleft, self.offset)
+            self.display_surface.blit(sprite.image, offset_position)

--- a/code/player.py
+++ b/code/player.py
@@ -3,6 +3,7 @@
 import pygame
 from settings import *
 from support import *
+from debug import *
 
 class Player(pygame.sprite.Sprite):
     def __init__(self, pos, PLAYER_SIZE, groups, obstacle_sprites):
@@ -182,11 +183,12 @@ class Player(pygame.sprite.Sprite):
         # 나중에 플레이어와 사물이 부딪힐 때를 대비해 player.rect 자체가 아니라 좀 더 작은 충돌 범위(hitbox)를 검사한다.
         self.hitbox.x += self.direction * self.speed * df
 
-        # 카메라 하면서 바꿔야 하는 부분. 일단 임시로 화면 width 안 벗어나게 해두었음.
+        # # 플레이어가 지정된 화면 밖으로 벗어나지 못하게 함.
+        # # 카메라 구현 과정에서 이대로 둘 것인지 obstacle 그룹을 만들어서 경계를 관리할 것인지 결정할 필요가 있음
         if self.hitbox.x < 0:
             self.hitbox.x = 0
-        if self.hitbox.x + self.rect.width > WIDTH:
-            self.hitbox.x = WIDTH - self.rect.width
+        if self.hitbox.x > 3200: # 바닥 이미지 크기 설정할 때 함께 바꿔주던가 해야함
+            self.hitbox.x = 3200
 
         if self.jumping:
             self.jump(df)

--- a/code/support.py
+++ b/code/support.py
@@ -40,3 +40,23 @@ def quit_check(event):
     if event.type == pygame.QUIT:
         pygame.quit()
         sys.exit()
+
+def add_Coordinate(coor1, coor2):
+    """
+    add coor2 to coor1
+    :param coor1: coordinate 1
+    :param coor2: coordinate 2
+    :return: (coor1[0] + coor2[0], coor1[1] + coor2[1]) -> tuple.
+    """
+    res = map(lambda x, y : x + y, coor1, coor2)
+    return res
+
+def sub_Coordinate(coor1, coor2):
+    """
+    subtract coor2 from coor1
+    :param coor1: coordinate 1
+    :param coor2: coordinate 2
+    :return: (coor1[0] - coor2[0], coor1[1] - coor2[1]) -> tuple.
+    """
+    res = map(lambda x, y : x - y, coor1, coor2)
+    return res


### PR DESCRIPTION
1. level.py 에서 카메라 구현시 사용한 pygame.math.Vector2 를 list로 바꾸었음.
2. 리스트와 좌표 계산이 다소 반복적이고 귀찮아서 support.py에 좌표 계산을 위한 더하기, 빼기 함수를 생성함.
    #좌표 두 개를 인자로 받아 x는 x끼리, y는 y끼리 계산하고 tuple을 return 하는 함수
    2 - 1) def add_Coordinate(coor1, coor2) -> tuple:
    2 - 2) def sub_Coordinate(coor1, coor2) -> tuple:

3. player.py 변경 부분 : move 함수에서 플레이어가 바닥 이미지 밖으로 나가지 않게 값을 수정하였음
    (카메라 구현 과정에서 추가 수정 가능한 부분)