### PR TITLE
Fix : Monster2 Hitbox Bug

### DIFF
--- a/code/Bringer.py
+++ b/code/Bringer.py
@@ -77,6 +77,11 @@ class Bringer(Monster):
 
         #마법 공격 쿨타임
         self.CastTime += df/ 1000.0
+
+        posX = self.targetPos
+        #중앙값으로 거리 계산 하기 위해 사이즈의 일정 비율을 더해준다.
+        monsterPosX = self.getHitBox()[0] + self.scale[0]/8
+        distanceX = monsterPosX - posX
        
         if ('hurt' in self.status) | ('death' in self.status) | ('attack' in self.status) | ('cast' in self.status)| ('idle' in self.status):
             if not self.animation_end:
@@ -94,12 +99,8 @@ class Bringer(Monster):
             else:
                 self.IdleTime = 0.0
 
-        posX = self.targetPos
-        monsterPosX = self.hitbox.topleft[0] - self.OffsetX
-        distanceX = monsterPosX - posX
-
         if self.CastTime < self.CastTimeMax:
-            if abs(distanceX) > 80:
+            if abs(distanceX) > 200:
                 if(distanceX)>=0:
                     self.status = 'walkL'
                     self.direction = -1
@@ -164,5 +165,12 @@ class Bringer(Monster):
 
     def setTargetPos(self, posX):
         self.targetPos = posX
+    
+    def getHitBox(self):
+        hitbox = self.hitbox.inflate(-BRINGER_SIZE[0]/4, -BRINGER_SIZE[1]/5*2)
+        return  sub_Coordinate(hitbox, (0 - self.OffsetX, -BRINGER_SIZE[1]/5, 0, 0))
+
+    def getAttackBox(self):
+        return self.attackbox                                              
 
  

--- a/code/BringerSpell.py
+++ b/code/BringerSpell.py
@@ -28,7 +28,7 @@ class BringerSpell(pygame.sprite.Sprite):
         self.image = pygame.image.load('image/Monster/bringer/spell.png').convert_alpha()
         self.image = pygame.transform.scale(self.image, SIZE)
         self.rect = self.image.get_rect(topleft=pos)
-        self.hitbox = self.rect.inflate(-SIZE[0]/3*2, 0)#이미지 사각형의 크기 줄여 HitBox로 사용 
+        self.hitbox = self.rect.inflate(-SIZE[0]/4*3, 0)#이미지 사각형의 크기 줄여 HitBox로 사용 
         self.scale = SIZE
         self.CameraOffset = [0,0]
         self.isAttack = False
@@ -63,7 +63,7 @@ class BringerSpell(pygame.sprite.Sprite):
 
     def ON(self, posX):
         self.SkillON = True
-        self.hitbox.x = posX + self.scale[0]/8
+        self.hitbox.x = posX - self.scale[0]/16
         self.hitbox.y = 250
 
     def animate(self, df):
@@ -106,10 +106,18 @@ class BringerSpell(pygame.sprite.Sprite):
     def update(self, df):
         self.animate(df)
         #어택 박스 정보 갱신
-        attack_hitbox = sub_Coordinate(self.hitbox, (self.CameraOffset[0], self.CameraOffset[1], 0, 0))
+        attackBox = pygame.Rect(self.hitbox)
+        attackBox = attackBox.inflate(-self.scale[0]/16, -self.scale[1]/3)
+        attack_hitbox = sub_Coordinate(attackBox, (self.CameraOffset[0], self.CameraOffset[1]-self.scale[1]/4, 0, 0))
+        
         if(self.frame_index < 11 and self.frame_index > 6):
             pygame.draw.rect(self.display_surface,(255, 255, 255), attack_hitbox, 3)
             self.isAttack = True
         else:
             self.isAttack = False
+
+    def getHitBox(self):
+        attackBox = pygame.Rect(self.hitbox)
+        attackBox = attackBox.inflate(-self.scale[0]/16, -self.scale[1]/3)
+
 

--- a/code/scene.py
+++ b/code/scene.py
@@ -50,9 +50,9 @@ class Scene:
         self.player.update(df)
 
         # 몬스터에게 플레이어 위치 전달 후 업데이트 # 용준? 코드인 것 같음
-        self.monster.setTargetPos(self.player.rect[0])
+        self.monster.setTargetPos(self.player.hitbox[0])
         self.monster.update(df)
-        debug("monster_hitbox : " + str(self.monster.hitbox), 10, 0)
+        debug("monster_hitbox : " + str(self.monster.getHitBox()), 10, 0)
         debug("player_hitbox : " + str(self.player.hitbox), 10, 40)
         debug("player_isAttack : " + str(self.player.isAttack), 10, 80)
         debug("Monster_isAttack : " + str(self.monster.isAttack), 10, 120)
@@ -174,5 +174,5 @@ class CameraGroup(pygame.sprite.Group): # for level1, level2, level3
                                                         0, 0)), 3)
         # 몬스터 히트박스 그리기
         pygame.draw.rect(self.display_surface, (255, 255, 255),
-                         sub_Coordinate(monster.hitbox, (self.offset[0] - monster.OffsetX, self.offset[1],
+                         sub_Coordinate(monster.getHitBox(), (self.offset[0] , self.offset[1],
                                                         0, 0)), 3)


### PR DESCRIPTION
Bringer.py : getHitBox(), getAttackBox() 함수 추가 및 히트박스 크기 조정, AI에서 플레이어와의 거리 계산할 때 TopLeft를 기준으로 계산하는 문제 수정

BringerSpell.py : getHitBox() 함수 추가 및 히트박스 크기 조정

scene.py : 몬스터 위치 정보 디버그용 출력시 몬스터의 hitbox를 직접 출력하는 것이 아닌 보정된 값을 출력하도록 변경
                몬스터에게 플레이어 위치 정보를 넘겨줄 때 rect 정보가 아닌 , hitbox 정보를 넘겨주는 것으로 수정