### PR TITLE
fix : monster spell kill with scene transition

### DIFF
--- a/code/level.py
+++ b/code/level.py
@@ -74,5 +74,6 @@ class Level:
             self.game_state = GAME_STATES[self.scene_num]
 
             self.monster.kill()  # 이전 레벨 몬스터 죽이기
+            self.monster.spell.kill() # 몬스터 스펠 죽이기
             self.monster = self.monster_create(self.game_state)  # 몬스터 생성
             self.scene = Scene(self.player, self.monster, self.scene_num, self.game_state, self.visible_sprites)  # 다음 장면 생성


### PR DESCRIPTION
수정 후 몬스터 스펠 스프라이트가 생성 중에 다음 스테이지로 넘어갈 경우, 
스프라이트 이미지가 다음 스테이지에도 계속해서 남아있는 현상 발견.
 -> 장면 교체시 몬스터 스프라이트 그룹 해제하면서 함께 몬스터 스펠도 그룹 해제 시켜줌으로써 해결.
